### PR TITLE
erm4 Acceso portal: implementar servicio consulta operador aprovisionado

### DIFF
--- a/src/config/errorCodes.tsx
+++ b/src/config/errorCodes.tsx
@@ -86,6 +86,26 @@ const errorCodes: Record<number, ErrorDetail> = {
     whatWentWrong: ["No se encontraron opciones para el empleado."],
     howToFix: ["Confirma que estés usando la url adecuada."],
   },
+  1006: {
+    whatWentWrong: [
+      "No se encontraron datos para el gestor de negocios.",
+      "El ID proporcionado no devolvió información válida.",
+    ],
+    howToFix: [
+      "Verifica que el ID del gestor de negocios sea correcto.",
+      "Asegúrate de que los datos necesarios estén configurados en el sistema.",
+    ],
+  },
+  1007: {
+    whatWentWrong: [
+      "Hubo un problema al intentar obtener los datos del gestor de negocios.",
+      "La solicitud falló debido a un error de red o del servidor.",
+    ],
+    howToFix: [
+      "Intenta nuevamente más tarde.",
+      "Si el problema persiste, contacta al equipo de soporte técnico.",
+    ],
+  },
 };
 
 export { errorCodes };

--- a/src/context/AppContext/index.tsx
+++ b/src/context/AppContext/index.tsx
@@ -5,17 +5,29 @@ import React, {
   useEffect,
   ReactNode,
 } from "react";
-import selsaLogo from "@assets/images/selsa.png";
 import { useAuth0 } from "@auth0/auth0-react";
-import { IAppContextType, IPreferences } from "./types";
+
+import selsaLogo from "@assets/images/selsa.png";
 import { IStaffPortalByBusinessManager } from "@ptypes/staffPortalBusiness.types";
+import { IBusinessManager } from "@src/types/employeePortalBusiness.types";
+
+import { IAppContextType, IPreferences } from "./types";
 
 const AppContext = createContext<IAppContextType | undefined>(undefined);
 
+const useAppContext = () => {
+  const context = useContext(AppContext);
+  if (!context) {
+    throw new Error("useAppContext must be used within an AppProvider");
+  }
+  return context;
+};
+
 const AppProvider: React.FC<{
   children: ReactNode;
+  businessManagersData: IBusinessManager;
   dataPortal: IStaffPortalByBusinessManager;
-}> = ({ children, dataPortal }) => {
+}> = ({ children, dataPortal, businessManagersData }) => {
   const { user: auth0User } = useAuth0();
   const [user, setUser] = useState<{
     username: string;
@@ -45,6 +57,9 @@ const AppProvider: React.FC<{
   const [provisionedPortal, setProvisionedPortal] =
     useState<IStaffPortalByBusinessManager>(dataPortal);
 
+  const [businessManagers, setBusinessManagers] =
+    useState<IBusinessManager>(businessManagersData);
+
   const updatePreferences = (newPreferences: Partial<IPreferences>) => {
     setPreferences((prev) => ({ ...prev, ...newPreferences }));
   };
@@ -70,6 +85,8 @@ const AppProvider: React.FC<{
         },
         provisionedPortal,
         setProvisionedPortal,
+        businessManagers,
+        setBusinessManagers,
       }}
     >
       {children}
@@ -77,12 +94,5 @@ const AppProvider: React.FC<{
   );
 };
 
-const useAppContext = () => {
-  const context = useContext(AppContext);
-  if (!context) {
-    throw new Error("useAppContext must be used within an AppProvider");
-  }
-  return context;
-};
-
-export { AppProvider, useAppContext };
+export { AppProvider };
+export { useAppContext };

--- a/src/context/AppContext/types.ts
+++ b/src/context/AppContext/types.ts
@@ -1,4 +1,16 @@
 import { IStaffPortalByBusinessManager } from "@ptypes/staffPortalBusiness.types";
+
+interface BusinessManager {
+  id: string;
+  publicCode: string;
+  language: string;
+  abbreviatedName: string;
+  description: string;
+  urlBrand: string;
+  urlLogo: string;
+  customerId: string;
+}
+
 export interface IPreferences {
   boardOrientation: "vertical" | "horizontal";
   showPinnedOnly: boolean;
@@ -29,14 +41,7 @@ export interface IAppContextType {
     company: string;
     urlImgPerfil: string;
   } | null;
-  setUser: React.Dispatch<
-    React.SetStateAction<{
-      username: string;
-      id: string;
-      company: string;
-      urlImgPerfil: string;
-    } | null>
-  >;
+  setUser: React.Dispatch<React.SetStateAction<IAppContextType["user"]>>;
   preferences: IPreferences;
   updatePreferences: (newPreferences: Partial<IPreferences>) => void;
   logoUrl: string;
@@ -47,4 +52,6 @@ export interface IAppContextType {
   setProvisionedPortal: React.Dispatch<
     React.SetStateAction<IStaffPortalByBusinessManager>
   >;
+  businessManagers: BusinessManager | null;
+  setBusinessManagers: React.Dispatch<React.SetStateAction<BusinessManager>>;
 }

--- a/src/hooks/useBusinessManagers.ts
+++ b/src/hooks/useBusinessManagers.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+
+import {
+  IBusinessManager,
+  IEmployeePortalByBusinessManager,
+} from "@src/types/employeePortalBusiness.types";
+import { getBusinessManagerById } from "@services/businessManagers/getBusinessManagerById";
+
+export const useBusinessManagers = (
+  portalPublicCode: IEmployeePortalByBusinessManager,
+) => {
+  const [businessManagersData, setBusinessManagersData] =
+    useState<IBusinessManager>({} as IBusinessManager);
+  const [hasError, setHasError] = useState(false);
+  const [codeError, setCodeError] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    const fetchBusinessManagers = async () => {
+      if (!portalPublicCode?.businessManagerId) return;
+
+      try {
+        const fetchedBusinessManagers = await getBusinessManagerById(
+          portalPublicCode.businessManagerId,
+        );
+
+        if (
+          !fetchedBusinessManagers ||
+          Object.keys(fetchedBusinessManagers).length === 0
+        ) {
+          setHasError(true);
+          setCodeError(1006);
+          return;
+        }
+
+        setBusinessManagersData(fetchedBusinessManagers);
+      } catch (err) {
+        console.error(
+          "Error al obtener los datos del gestor de negocios:",
+          err,
+        );
+        setHasError(true);
+        setCodeError(1007);
+      }
+    };
+
+    fetchBusinessManagers();
+  }, [portalPublicCode]);
+
+  return { businessManagersData, hasError, codeError };
+};

--- a/src/services/businessManagers/getBusinessManagerById/index.tsx
+++ b/src/services/businessManagers/getBusinessManagerById/index.tsx
@@ -1,0 +1,69 @@
+import {
+  environment,
+  fetchTimeoutServices,
+  maxRetriesServices,
+} from "@config/environment";
+
+import { IBusinessManager } from "@src/types/employeePortalBusiness.types";
+
+import { mapBusinessManagerApiToEntity } from "./mappers";
+
+const getBusinessManagerById = async (
+  businessManagerId: string,
+): Promise<IBusinessManager> => {
+  const maxRetries = maxRetriesServices;
+  const fetchTimeout = fetchTimeoutServices;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), fetchTimeout);
+
+      const options: RequestInit = {
+        method: "GET",
+        headers: {
+          "X-Action": "SearchByIdBusinessManager",
+          "Content-type": "application/json; charset=UTF-8",
+        },
+        signal: controller.signal,
+      };
+
+      const res = await fetch(
+        `${environment.IVITE_ISAAS_QUERY_PROCESS_SERVICE}/business-managers/${businessManagerId}`,
+        options,
+      );
+
+      clearTimeout(timeoutId);
+
+      if (res.status === 204) {
+        return {} as IBusinessManager;
+      }
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw {
+          message: "Error al obtener los datos del operador",
+          status: res.status,
+          data,
+        };
+      }
+
+      return mapBusinessManagerApiToEntity(data);
+    } catch (error) {
+      if (attempt === maxRetries) {
+        throw new Error(
+          `Todos los intentos fallaron. No se pudieron obtener los datos del operador. Error: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+
+      continue;
+    }
+  }
+
+  return {} as IBusinessManager;
+};
+
+export { getBusinessManagerById };

--- a/src/services/businessManagers/getBusinessManagerById/mappers.ts
+++ b/src/services/businessManagers/getBusinessManagerById/mappers.ts
@@ -1,0 +1,26 @@
+import { IBusinessManager } from "@src/types/employeePortalBusiness.types";
+
+const mapBusinessManagerApiToEntity = (
+  businessManager: Record<string, unknown>,
+): IBusinessManager => {
+  const toStringSafe = (value: unknown): string => {
+    if (typeof value === "string" || typeof value === "number") {
+      return String(value);
+    }
+    return "";
+  };
+
+  const business: IBusinessManager = {
+    id: toStringSafe(businessManager.businessManagerId),
+    publicCode: toStringSafe(businessManager.publicCode),
+    language: toStringSafe(businessManager.languageId),
+    abbreviatedName: toStringSafe(businessManager.abbreviatedName),
+    description: toStringSafe(businessManager.descriptionUse),
+    urlBrand: toStringSafe(businessManager.urlBrand),
+    urlLogo: toStringSafe(businessManager.urlLogo),
+    customerId: toStringSafe(businessManager.customerId),
+  };
+  return business;
+};
+
+export { mapBusinessManagerApiToEntity };

--- a/src/types/employeePortalBusiness.types.ts
+++ b/src/types/employeePortalBusiness.types.ts
@@ -1,0 +1,33 @@
+interface IOptionsByEmployeePortalBusinessManager {
+  optionEmployeeId: string;
+  employeePortalCatalogId: string;
+  employeePortalId: string;
+}
+
+interface IEmployeePortalByBusinessManager {
+  abbreviatedName: string;
+  businessManagerId: string;
+  businessUnit: string;
+  descriptionUse: string;
+  portalCode: string;
+  employeePortalCatalogId: string;
+  employeePortalId: string;
+  optionsByEmployeePortalBusinessManager?: IOptionsByEmployeePortalBusinessManager[];
+}
+
+interface IBusinessManager {
+  id: string;
+  publicCode: string;
+  language: string;
+  abbreviatedName: string;
+  description: string;
+  urlBrand: string;
+  urlLogo: string;
+  customerId: string;
+}
+
+export type {
+  IBusinessManager,
+  IEmployeePortalByBusinessManager,
+  IOptionsByEmployeePortalBusinessManager,
+};

--- a/src/types/staffPortalBusiness.types.ts
+++ b/src/types/staffPortalBusiness.types.ts
@@ -1,18 +1,16 @@
+import { IEmployeePortalByBusinessManager } from "./employeePortalBusiness.types";
+
 interface IOptionsByStaffPortalBusinessManager {
   optionStaffId: string;
   staffPortalCatalogId: string;
   staffPortalId: string;
 }
 
-interface IStaffPortalByBusinessManager {
-  abbreviatedName: string;
-  businessManagerId: string;
-  descriptionUse: string;
-  optionsByStaffPortalBusinessManager: IOptionsByStaffPortalBusinessManager[];
+interface IStaffPortalByBusinessManager
+  extends IEmployeePortalByBusinessManager {
   publicCode: string;
-  staffPortalCatalogId: string;
-  staffPortalId: string;
   url: string;
+  optionsByStaffPortalBusinessManager: IOptionsByStaffPortalBusinessManager[];
 }
 
 export type { IStaffPortalByBusinessManager };


### PR DESCRIPTION
Descripción:

Se debe consumir el servicio que consulta el operador, donde se debe validar si existe el operador, el entpoint retorna datos debe redirigirlo al appPage y si no existe el operador redireccionarlo a la pagina de error. Esta consulta debe ser despues del consumo [consulta aprovisionado](https://inube.atlassian.net/browse/ERM-3)

En la pagina de error debe mencionar una descripción del error que genero.

Documento de servicio:

http://172.106.48.22:8020/swagger/index.html#/BusinessManager/get_business_managers__businessManagerId__AC_SearchByIdBusinessManager_

como parametro del servicio se debe enviar businessManagerId donde esta almacenado en el context 

Criterios de aceptacion:

Si no se encuentran un operador se debe redireccionar a la página de error

Si se encuentra un operador se debe redireccionar a la página de bienvenida

Se debe quedar almacenado los datos del operador y unidad de negocio en el context de la aplicación

Los datos del entpoint consumidos debe estar en el context

Se debe validar si el servicio genero error, si es así debe desencadenar un flag con la descripción “Error en la consulta del operador“