### PR TITLE
erm49 Creación de sección que muestra los contratos

### DIFF
--- a/src/components/cards/ContractCard/index.tsx
+++ b/src/components/cards/ContractCard/index.tsx
@@ -35,6 +35,7 @@ function ContractCard(props: ContractCardProps) {
       alignItems="center"
       width="212px"
       gap={spacing.s100}
+      padding={spacing.s150}
     >
       <Text
         type="title"

--- a/src/components/layout/AppPage/index.tsx
+++ b/src/components/layout/AppPage/index.tsx
@@ -60,7 +60,6 @@ function AppPage(props: AppPageProps) {
           <Grid
             templateColumns={withNav && !isTablet ? "auto 1fr" : "1fr"}
             alignContent="unset"
-            height="85vh"
           >
             {withNav && !isTablet && (
               <Nav navigation={nav} actions={actions} collapse={true} />

--- a/src/components/layout/AppPage/index.tsx
+++ b/src/components/layout/AppPage/index.tsx
@@ -60,7 +60,7 @@ function AppPage(props: AppPageProps) {
           <Grid
             templateColumns={withNav && !isTablet ? "auto 1fr" : "1fr"}
             alignContent="unset"
-            height="95vh"
+            height="85vh"
           >
             {withNav && !isTablet && (
               <Nav navigation={nav} actions={actions} collapse={true} />

--- a/src/components/layout/AppPage/styles.ts
+++ b/src/components/layout/AppPage/styles.ts
@@ -1,6 +1,8 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
+import { spacing } from "@design/tokens/spacing";
+
 const StyledAppPage = styled.div`
   display: inherit;
   box-sizing: border-box;
@@ -15,6 +17,7 @@ const StyledMain = styled.main`
   box-sizing: border-box;
   height: calc(100vh - 54px);
   overflow-y: auto;
+  padding-bottom: ${spacing.s600};
 `;
 const StyledContentImg = styled(Link)`
   width: 100px;

--- a/src/components/layout/AppPage/styles.ts
+++ b/src/components/layout/AppPage/styles.ts
@@ -11,6 +11,10 @@ const StyledAppPage = styled.div`
 const StyledContainer = styled.div`
   display: inherit;
   overflow: hidden;
+
+  nav {
+    height: 95%;
+  }
 `;
 
 const StyledMain = styled.main`

--- a/src/mocks/contracts/contracts.mock.tsx
+++ b/src/mocks/contracts/contracts.mock.tsx
@@ -1,0 +1,34 @@
+import { ContractCardProps } from "@components/cards/ContractCard";
+
+export const contractCardMock: ContractCardProps[] = [
+  {
+    isContractValid: true,
+    lastSalary: 3290000,
+    startDate: "02/Sep/2024",
+    endDate: "Indefinido",
+    lastCharge: "Cargo anterior",
+    contractType: "Tiempo completo",
+    normativeFramework: "Marco XYZ",
+    company: "Empresa ABC",
+  },
+  {
+    isContractValid: false,
+    lastSalary: 2500000,
+    startDate: "15/Mar/2022",
+    endDate: "20/Ago/2023",
+    lastCharge: "Analista de datos",
+    contractType: "Contrato por obra",
+    normativeFramework: "Ley 123",
+    company: "Empresa DEF",
+  },
+  {
+    isContractValid: true,
+    lastSalary: 4200000,
+    startDate: "10/Jun/2023",
+    endDate: "30/Nov/2026",
+    lastCharge: "Desarrollador Senior",
+    contractType: "Indefinido",
+    normativeFramework: "Norma ABC",
+    company: "Empresa GHI",
+  },
+];

--- a/src/pages/contracts/Actions/config.tsx
+++ b/src/pages/contracts/Actions/config.tsx
@@ -1,0 +1,46 @@
+import {
+  MdAdd,
+  MdOutlineCancel,
+  MdUpdate,
+  MdOutlineEdit,
+} from "react-icons/md";
+
+import { IAction } from "./type";
+
+export const Actions = (
+  onClickAdd?: () => void,
+  onClickModify?: () => void,
+  onClickRenew?: () => void,
+  onClickEliminate?: () => void,
+): IAction[] => {
+  return [
+    {
+      icon: <MdAdd />,
+      appearance: "primary",
+      label: "Agregar",
+      onClick: onClickAdd,
+      isDisabled: true,
+    },
+    {
+      icon: <MdOutlineEdit />,
+      appearance: "primary",
+      label: "Modificar",
+      onClick: onClickModify,
+      isDisabled: true,
+    },
+    {
+      icon: <MdUpdate />,
+      appearance: "primary",
+      label: "Renovar",
+      onClick: onClickRenew,
+      isDisabled: true,
+    },
+    {
+      icon: <MdOutlineCancel />,
+      appearance: "danger",
+      label: "Terminar",
+      onClick: onClickEliminate,
+      isDisabled: true,
+    },
+  ];
+};

--- a/src/pages/contracts/Actions/index.tsx
+++ b/src/pages/contracts/Actions/index.tsx
@@ -1,30 +1,38 @@
 import { Stack, Text, Icon } from "@inubekit/inubekit";
-import { MdOutlineInfo } from "react-icons/md";
+import { MdOutlineInfo, MdClose } from "react-icons/md";
 
-import { StyledContainer, StyledLi, StyledUl, StyledActions } from "./styles";
+import {
+  StyledContainer,
+  StyledLi,
+  StyledUl,
+  StyledActions,
+  StyledCloseIcon,
+} from "./styles";
 import { Actions } from "./config";
 
 interface ActionModalProps {
-  onClickEdit?: () => void;
-  onClickEliminate?: () => void;
-  onClickAdd?: () => void;
-  onClickRenew?: () => void;
   disableDeleteAction?: boolean;
   disableModifyAction?: boolean;
   disableRenewAction?: boolean;
   disableAddAction?: boolean;
+  onClickEdit?: () => void;
+  onClickEliminate?: () => void;
+  onClickAdd?: () => void;
+  onClickRenew?: () => void;
+  onClose?: () => void;
 }
 
 export function ActionModal(props: ActionModalProps) {
   const {
-    onClickEdit,
-    onClickEliminate,
-    onClickAdd,
-    onClickRenew,
     disableDeleteAction,
     disableModifyAction,
     disableRenewAction,
     disableAddAction,
+    onClickEdit,
+    onClickEliminate,
+    onClickAdd,
+    onClickRenew,
+    onClose,
   } = props;
 
   const actionsLi = Actions(
@@ -34,54 +42,30 @@ export function ActionModal(props: ActionModalProps) {
     onClickEliminate,
   );
 
-  const addActionIndex = actionsLi.findIndex(
-    (item) => item.label === "Agregar",
-  );
-  if (addActionIndex !== -1) {
-    actionsLi[addActionIndex].onClick = onClickAdd;
-    actionsLi[addActionIndex].isDisabled = disableAddAction ?? !onClickAdd;
-    if (actionsLi[addActionIndex].isDisabled) {
-      actionsLi[addActionIndex].appearance = "gray";
-    }
-  }
+  const modifyActions = [
+    { label: "Agregar", onClick: onClickAdd, disable: disableAddAction },
+    { label: "Modificar", onClick: onClickEdit, disable: disableModifyAction },
+    { label: "Renovar", onClick: onClickRenew, disable: disableRenewAction },
+    {
+      label: "Terminar",
+      onClick: onClickEliminate,
+      disable: disableDeleteAction,
+      danger: true,
+    },
+  ];
 
-  const modifyActionIndex = actionsLi.findIndex(
-    (item) => item.label === "Modificar",
-  );
-  if (modifyActionIndex !== -1) {
-    actionsLi[modifyActionIndex].onClick = onClickEdit;
-    actionsLi[modifyActionIndex].isDisabled =
-      disableModifyAction ?? !onClickEdit;
-    if (actionsLi[modifyActionIndex].isDisabled) {
-      actionsLi[modifyActionIndex].appearance = "gray";
+  modifyActions.forEach(({ label, onClick, disable, danger }) => {
+    const actionIndex = actionsLi.findIndex((item) => item.label === label);
+    if (actionIndex !== -1) {
+      actionsLi[actionIndex].onClick = onClick;
+      actionsLi[actionIndex].isDisabled = disable ?? !onClick;
+      actionsLi[actionIndex].appearance = actionsLi[actionIndex].isDisabled
+        ? "gray"
+        : danger
+          ? "danger"
+          : actionsLi[actionIndex].appearance;
     }
-  }
-
-  const renewActionIndex = actionsLi.findIndex(
-    (item) => item.label === "Renovar",
-  );
-  if (renewActionIndex !== -1) {
-    actionsLi[renewActionIndex].onClick = onClickRenew;
-    actionsLi[renewActionIndex].isDisabled =
-      disableRenewAction ?? !onClickRenew;
-    if (actionsLi[renewActionIndex].isDisabled) {
-      actionsLi[renewActionIndex].appearance = "gray";
-    }
-  }
-
-  const deleteActionIndex = actionsLi.findIndex(
-    (item) => item.label === "Terminar",
-  );
-  if (deleteActionIndex !== -1) {
-    actionsLi[deleteActionIndex].onClick = onClickEliminate;
-    actionsLi[deleteActionIndex].isDisabled =
-      disableDeleteAction ?? !onClickEliminate;
-    if (actionsLi[deleteActionIndex].isDisabled) {
-      actionsLi[deleteActionIndex].appearance = "gray";
-    } else {
-      actionsLi[deleteActionIndex].appearance = "danger";
-    }
-  }
+  });
 
   return (
     <StyledContainer>
@@ -124,6 +108,15 @@ export function ActionModal(props: ActionModalProps) {
               </StyledLi>
             ))}
           </StyledUl>
+          <StyledCloseIcon>
+            <Icon
+              icon={<MdClose />}
+              appearance="dark"
+              size="18px"
+              onClick={onClose}
+              cursorHover
+            />
+          </StyledCloseIcon>
         </Stack>
       </StyledActions>
     </StyledContainer>

--- a/src/pages/contracts/Actions/index.tsx
+++ b/src/pages/contracts/Actions/index.tsx
@@ -1,0 +1,131 @@
+import { Stack, Text, Icon } from "@inubekit/inubekit";
+import { MdOutlineInfo } from "react-icons/md";
+
+import { StyledContainer, StyledLi, StyledUl, StyledActions } from "./styles";
+import { Actions } from "./config";
+
+interface ActionModalProps {
+  onClickEdit?: () => void;
+  onClickEliminate?: () => void;
+  onClickAdd?: () => void;
+  onClickRenew?: () => void;
+  disableDeleteAction?: boolean;
+  disableModifyAction?: boolean;
+  disableRenewAction?: boolean;
+  disableAddAction?: boolean;
+}
+
+export function ActionModal(props: ActionModalProps) {
+  const {
+    onClickEdit,
+    onClickEliminate,
+    onClickAdd,
+    onClickRenew,
+    disableDeleteAction,
+    disableModifyAction,
+    disableRenewAction,
+    disableAddAction,
+  } = props;
+
+  const actionsLi = Actions(
+    onClickAdd,
+    onClickEdit,
+    onClickRenew,
+    onClickEliminate,
+  );
+
+  const addActionIndex = actionsLi.findIndex(
+    (item) => item.label === "Agregar",
+  );
+  if (addActionIndex !== -1) {
+    actionsLi[addActionIndex].onClick = onClickAdd;
+    actionsLi[addActionIndex].isDisabled = disableAddAction ?? !onClickAdd;
+    if (actionsLi[addActionIndex].isDisabled) {
+      actionsLi[addActionIndex].appearance = "gray";
+    }
+  }
+
+  const modifyActionIndex = actionsLi.findIndex(
+    (item) => item.label === "Modificar",
+  );
+  if (modifyActionIndex !== -1) {
+    actionsLi[modifyActionIndex].onClick = onClickEdit;
+    actionsLi[modifyActionIndex].isDisabled =
+      disableModifyAction ?? !onClickEdit;
+    if (actionsLi[modifyActionIndex].isDisabled) {
+      actionsLi[modifyActionIndex].appearance = "gray";
+    }
+  }
+
+  const renewActionIndex = actionsLi.findIndex(
+    (item) => item.label === "Renovar",
+  );
+  if (renewActionIndex !== -1) {
+    actionsLi[renewActionIndex].onClick = onClickRenew;
+    actionsLi[renewActionIndex].isDisabled =
+      disableRenewAction ?? !onClickRenew;
+    if (actionsLi[renewActionIndex].isDisabled) {
+      actionsLi[renewActionIndex].appearance = "gray";
+    }
+  }
+
+  const deleteActionIndex = actionsLi.findIndex(
+    (item) => item.label === "Terminar",
+  );
+  if (deleteActionIndex !== -1) {
+    actionsLi[deleteActionIndex].onClick = onClickEliminate;
+    actionsLi[deleteActionIndex].isDisabled =
+      disableDeleteAction ?? !onClickEliminate;
+    if (actionsLi[deleteActionIndex].isDisabled) {
+      actionsLi[deleteActionIndex].appearance = "gray";
+    } else {
+      actionsLi[deleteActionIndex].appearance = "danger";
+    }
+  }
+
+  return (
+    <StyledContainer>
+      <StyledActions>
+        <Stack>
+          <StyledUl>
+            {actionsLi.map((item, index) => (
+              <StyledLi
+                key={index}
+                onClick={(event) => {
+                  if (item.isDisabled) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    return;
+                  }
+                  item.onClick?.();
+                }}
+                $isDisabled={item.isDisabled}
+              >
+                <Icon
+                  icon={item.icon}
+                  appearance={item.appearance}
+                  disabled={item.isDisabled}
+                  size="18px"
+                />
+                <Text
+                  size="medium"
+                  appearance={item.isDisabled ? "gray" : "dark"}
+                >
+                  {item.label}
+                </Text>
+                {item.isDisabled && (
+                  <Icon
+                    icon={<MdOutlineInfo />}
+                    appearance="primary"
+                    size="16px"
+                    cursorHover
+                  />
+                )}
+              </StyledLi>
+            ))}
+          </StyledUl>
+        </Stack>
+      </StyledActions>
+    </StyledContainer>
+  );
+}

--- a/src/pages/contracts/Actions/styles.ts
+++ b/src/pages/contracts/Actions/styles.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/inubekit";
+
+import { spacing } from "@design/tokens/spacing";
+
+interface IStyledActions {
+  theme: typeof inube;
+}
+
+interface IStyledLi {
+  theme: typeof inube;
+  $isDisabled: boolean;
+}
+
+const StyledContainer = styled.div`
+  position: relative;
+`;
+
+const StyledUl = styled.ul`
+  margin: 0px;
+  padding: 0px;
+`;
+
+const StyledLi = styled.li<IStyledLi>`
+  list-style: none;
+  display: flex;
+  align-items: center;
+  padding: 7px 60px 7px 16px;
+  gap: ${spacing.s050};
+  cursor: pointer;
+`;
+
+const StyledActions = styled.div<IStyledActions>`
+  border-radius: 8px;
+  width: 162px;
+  height: 144px;
+  position: absolute;
+  z-index: 999;
+  right: 10px;
+  top: 100%;
+  background-color: ${({ theme }) =>
+    theme?.palette?.neutral?.N0 || inube.palette.neutral.N0};
+  box-shadow: 0px 2px 6px 1px
+    ${({ theme }) => theme?.palette?.neutral?.N40 || inube.palette.neutral.N40};
+`;
+
+export { StyledContainer, StyledUl, StyledLi, StyledActions };

--- a/src/pages/contracts/Actions/styles.ts
+++ b/src/pages/contracts/Actions/styles.ts
@@ -44,4 +44,10 @@ const StyledActions = styled.div<IStyledActions>`
     ${({ theme }) => theme?.palette?.neutral?.N40 || inube.palette.neutral.N40};
 `;
 
-export { StyledContainer, StyledUl, StyledLi, StyledActions };
+const StyledCloseIcon = styled.div`
+  position: absolute;
+  right: 10px;
+  top: 8px;
+`;
+
+export { StyledContainer, StyledUl, StyledLi, StyledActions, StyledCloseIcon };

--- a/src/pages/contracts/Actions/type.ts
+++ b/src/pages/contracts/Actions/type.ts
@@ -1,0 +1,10 @@
+import { IIconAppearance } from "@inubekit/inubekit";
+
+interface IAction {
+  icon: React.ReactNode;
+  appearance: IIconAppearance;
+  label: string;
+  isDisabled: boolean;
+  onClick?: () => void;
+}
+export type { IAction };

--- a/src/pages/contracts/Detail/index.tsx
+++ b/src/pages/contracts/Detail/index.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { MdOutlineMoreVert } from "react-icons/md";
+import { Stack, Icon } from "@inubekit/inubekit";
+
+import { ActionModal } from "../Actions";
+
+interface DetailProps {
+  onClickEdit?: () => void;
+  onClickEliminate?: () => void;
+  onClickAdd?: () => void;
+  onClickRenew?: () => void;
+  disableDeleteAction?: boolean;
+  disableModifyAction?: boolean;
+  disableRenewAction?: boolean;
+  disableAddAction?: boolean;
+}
+
+export function Detail(props: DetailProps) {
+  const {
+    onClickEdit,
+    onClickEliminate,
+    onClickAdd,
+    onClickRenew,
+    disableDeleteAction,
+    disableModifyAction,
+    disableRenewAction,
+    disableAddAction,
+  } = props;
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <Stack justifyContent="center">
+      <Icon
+        icon={<MdOutlineMoreVert />}
+        appearance="dark"
+        size="24px"
+        onClick={() => setModalOpen(!modalOpen)}
+        cursorHover
+      />
+      {modalOpen && (
+        <ActionModal
+          onClickEdit={onClickEdit}
+          onClickEliminate={onClickEliminate}
+          onClickAdd={onClickAdd}
+          onClickRenew={onClickRenew}
+          disableDeleteAction={disableDeleteAction}
+          disableModifyAction={disableModifyAction}
+          disableRenewAction={disableRenewAction}
+          disableAddAction={disableAddAction}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/src/pages/contracts/Detail/index.tsx
+++ b/src/pages/contracts/Detail/index.tsx
@@ -40,14 +40,15 @@ export function Detail(props: DetailProps) {
       />
       {modalOpen && (
         <ActionModal
-          onClickEdit={onClickEdit}
-          onClickEliminate={onClickEliminate}
-          onClickAdd={onClickAdd}
-          onClickRenew={onClickRenew}
           disableDeleteAction={disableDeleteAction}
           disableModifyAction={disableModifyAction}
           disableRenewAction={disableRenewAction}
           disableAddAction={disableAddAction}
+          onClickEdit={onClickEdit}
+          onClickEliminate={onClickEliminate}
+          onClickAdd={onClickAdd}
+          onClickRenew={onClickRenew}
+          onClose={() => setModalOpen(false)}
         />
       )}
     </Stack>

--- a/src/pages/contracts/interface.tsx
+++ b/src/pages/contracts/interface.tsx
@@ -1,19 +1,243 @@
+import {
+  useMediaQuery,
+  Stack,
+  Text,
+  Button,
+  Icon,
+  Tag,
+} from "@inubekit/inubekit";
+import { MdOutlineAdd, MdOutlineInfo } from "react-icons/md";
+
+import { spacing } from "@design/tokens/spacing";
 import { AppMenu } from "@components/layout/AppMenu";
 import { IRoute } from "@components/layout/AppMenu/types";
+import { ContractCard } from "@components/cards/ContractCard";
+import { contractCardMock } from "@mocks/contracts/contracts.mock";
+
+import {
+  StyledContractsContainer,
+  StyledSeparatorLine,
+  StyledAddVinculation,
+  StyledAddVinculationMobile,
+} from "./styles";
+import { Detail } from "./Detail";
 
 interface ContractsUIProps {
   appName: string;
   appRoute: IRoute[];
   navigatePage: string;
+  hasPendingRequest?: boolean;
+  canCreateRequest?: boolean;
 }
 
 function ContractsUI(props: ContractsUIProps) {
-  const { appName, appRoute, navigatePage } = props;
+  const {
+    appName,
+    appRoute,
+    navigatePage,
+    hasPendingRequest = false,
+    canCreateRequest = false,
+  } = props;
+  const isTablet = useMediaQuery("(max-width: 1235px)");
+  const isMobile = useMediaQuery("(max-width: 550px)");
+
+  const hasFixedEndDate = contractCardMock.some(
+    (contract) => contract.endDate !== "Indefinido",
+  );
+
+  const sortedContracts = [...contractCardMock].sort(
+    (a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime(),
+  );
+
+  const hasValidContract = contractCardMock.some(
+    (contract) => contract.isContractValid,
+  );
+
+  const handleTerminate = () => {
+    console.log("Terminate contract");
+  };
+
+  const handleRenew = () => {
+    console.log("Renew contract");
+  };
+
+  const handleModify = () => {
+    console.log("Modify contract");
+  };
+
+  const handleAddVinculation = () => {
+    console.log("Add Vinculation");
+  };
 
   return (
-    <AppMenu appName={appName} appRoute={appRoute} navigatePage={navigatePage}>
-      <></>
-    </AppMenu>
+    <>
+      <AppMenu
+        appName={appName}
+        appRoute={appRoute}
+        navigatePage={navigatePage}
+      >
+        <StyledContractsContainer $isMobile={isMobile}>
+          <Stack justifyContent="space-between">
+            <Text type="title" size="medium">
+              Consulta histórica de contratos
+            </Text>
+            {isTablet && (
+              <Detail
+                onClickEdit={hasValidContract ? handleModify : undefined}
+                onClickEliminate={
+                  hasValidContract ? handleTerminate : undefined
+                }
+                onClickAdd={canCreateRequest ? handleAddVinculation : undefined}
+                onClickRenew={
+                  hasFixedEndDate && hasValidContract ? handleRenew : undefined
+                }
+                disableModifyAction={!hasValidContract}
+                disableRenewAction={!hasFixedEndDate || !hasValidContract}
+                disableDeleteAction={!hasValidContract}
+                disableAddAction={!canCreateRequest}
+              />
+            )}
+            {!isTablet && (
+              <Stack gap={spacing.s150}>
+                <Stack gap={spacing.s025} alignItems="center">
+                  <Button
+                    appearance="danger"
+                    spacing="compact"
+                    variant="outlined"
+                    disabled={!hasValidContract}
+                    cursorHover
+                    onClick={hasValidContract ? handleTerminate : undefined}
+                  >
+                    Terminar
+                  </Button>
+                  {!hasValidContract && (
+                    <Icon
+                      icon={<MdOutlineInfo />}
+                      appearance="primary"
+                      size="16px"
+                      cursorHover
+                    />
+                  )}
+                </Stack>
+                <Stack gap={spacing.s025} alignItems="center">
+                  <Button
+                    disabled={!hasFixedEndDate || !hasValidContract}
+                    variant="outlined"
+                    cursorHover
+                    spacing="compact"
+                    onClick={
+                      hasFixedEndDate && hasValidContract
+                        ? handleRenew
+                        : undefined
+                    }
+                  >
+                    Renovar
+                  </Button>
+                  {(!hasFixedEndDate || !hasValidContract) && (
+                    <Icon
+                      icon={<MdOutlineInfo />}
+                      appearance="primary"
+                      size="16px"
+                      cursorHover
+                    />
+                  )}
+                </Stack>
+                <StyledSeparatorLine />
+                <Stack gap={spacing.s025} alignItems="center">
+                  <Button
+                    cursorHover
+                    spacing="compact"
+                    disabled={!hasValidContract}
+                    onClick={hasValidContract ? handleModify : undefined}
+                  >
+                    Modificar
+                  </Button>
+                  {!hasValidContract && (
+                    <Icon
+                      icon={<MdOutlineInfo />}
+                      appearance="primary"
+                      size="16px"
+                      cursorHover
+                    />
+                  )}
+                </Stack>
+                <Stack gap={spacing.s025} alignItems="center">
+                  <Button
+                    disabled={!canCreateRequest}
+                    iconBefore={<MdOutlineAdd />}
+                    cursorHover
+                    spacing="compact"
+                    onClick={
+                      canCreateRequest ? handleAddVinculation : undefined
+                    }
+                  >
+                    Agregar vinculación
+                  </Button>
+                  {!canCreateRequest && (
+                    <Icon
+                      icon={<MdOutlineInfo />}
+                      appearance="primary"
+                      size="16px"
+                      cursorHover
+                    />
+                  )}
+                </Stack>
+              </Stack>
+            )}
+          </Stack>
+
+          {!hasValidContract && (
+            <Stack>
+              <Tag
+                appearance={hasPendingRequest ? "primary" : "danger"}
+                label={
+                  hasPendingRequest
+                    ? "El empleado NO tiene un contrato vigente, PERO tiene una solicitud de vinculación en trámite."
+                    : "El empleado NO tiene ningún contrato vigente."
+                }
+              />
+            </Stack>
+          )}
+
+          <Stack
+            wrap="wrap"
+            gap={isMobile ? spacing.s200 : spacing.s300}
+            alignItems="flex-end"
+            justifyContent={isMobile ? "center" : "flex-start"}
+          >
+            {sortedContracts.map((contract, index) => (
+              <ContractCard key={index} {...contract} />
+            ))}
+            {canCreateRequest && !isTablet && (
+              <StyledAddVinculation>
+                <Icon
+                  appearance="gray"
+                  icon={<MdOutlineAdd />}
+                  size="45px"
+                  onClick={canCreateRequest ? handleAddVinculation : undefined}
+                  cursorHover={canCreateRequest}
+                />
+                <Text appearance="gray">Agregar vinculación</Text>
+              </StyledAddVinculation>
+            )}
+          </Stack>
+        </StyledContractsContainer>
+      </AppMenu>
+      {isTablet && canCreateRequest && (
+        <StyledAddVinculationMobile>
+          <Icon
+            appearance="primary"
+            variant="filled"
+            spacing="wide"
+            shape="circle"
+            icon={<MdOutlineAdd />}
+            size="50px"
+            cursorHover={canCreateRequest}
+            onClick={canCreateRequest ? handleAddVinculation : undefined}
+          />
+        </StyledAddVinculationMobile>
+      )}
+    </>
   );
 }
 

--- a/src/pages/contracts/styles.ts
+++ b/src/pages/contracts/styles.ts
@@ -1,0 +1,64 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/inubekit";
+
+import { spacing } from "@design/tokens/spacing";
+
+interface StyledContractsContainerProps {
+  $isMobile: boolean;
+  theme?: typeof inube;
+}
+
+const StyledContractsContainer = styled.div<StyledContractsContainerProps>`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.s250};
+  border-radius: ${spacing.s100};
+  border: 1px solid
+    ${({ theme }) =>
+      theme && theme.palette?.neutral?.N30
+        ? theme.palette.neutral.N30
+        : inube.palette.neutral.N30};
+  padding: ${({ $isMobile }) =>
+    $isMobile ? `${spacing.s300} ${spacing.s150}` : spacing.s300};
+`;
+
+const StyledSeparatorLine = styled.hr`
+  width: 2px;
+  margin: 0px;
+  border: 0px;
+  background-color: ${({ theme }) =>
+    theme?.palette?.neutral?.N30 || inube.palette.neutral.N30};
+`;
+
+const StyledAddVinculation = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 236px;
+  height: 368px;
+  margin-bottom: ${spacing.s150};
+  border-radius: 8px;
+  box-shadow: 0px 2px 6px 1px
+    ${({ theme }) => theme?.palette?.neutral?.N50 || inube.palette.neutral.N50};
+  user-select: none;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) =>
+      theme?.palette?.neutral?.N30 || inube.palette.neutral.N30};
+  }
+`;
+
+const StyledAddVinculationMobile = styled.div`
+  position: fixed;
+  right: ${spacing.s400};
+  bottom: ${spacing.s500};
+`;
+
+export {
+  StyledContractsContainer,
+  StyledSeparatorLine,
+  StyledAddVinculation,
+  StyledAddVinculationMobile,
+};


### PR DESCRIPTION
**Use cases:**

1. If there are no contracts with a fixed-term or defined end date, the renew button is not activated.
2. If there is at least one contract with a fixed or defined term, the renew button is activated.
3. The details modal is developed in another task.
4. All contracts, regardless of whether they are current or not, are organized from newest to oldest.
5. If the employee does not have a current contract but has a request (it was only configured as a Boolean prop while obtaining data from the context), the tag is displayed in its primary version.
6. If the employee does not have a current contract, the tag is displayed in its danger version.
7. The contract selection modal used in Renew, Modify, and Terminate is created in another task.
8. If the employee has privileges to create requests, the link button is activated (it was only configured as a Boolean prop while obtaining data from the context)


Create a section displaying the employee's contracts, as shown in [Figma](https://www.figma.com/design/ZgYt9E6YnXdE56JlkNMEnr/ERM-portal?node-id=69-10512&p=f&t=Rqmb6rv5t0UPC9qF-0).

![image](https://github.com/user-attachments/assets/f2f2300f-6cc5-4730-9222-18f0108aeaa6)

To do this, integrate the cards created in task #48; the data for each contract is in the context of the selected employee.
In this task, add the "Terminate," "Renew," and "Modify" buttons. These buttons should not work, as they are disabled depending on the contract type or privilege. The latter is done through a service consumption that will be integrated later.

This task must have the "Add Binding" card.

Acceptance criteria:

Must have the same dimensions as the mockup.
Must have a mobile version.
Must have no errors in the console or in TypeScript compilation.
The privileges of each button that displays a message must be taken into account.