### PR TITLE
erm51 Modal selección de contrato

### DIFF
--- a/src/components/cards/ContractCard/index.tsx
+++ b/src/components/cards/ContractCard/index.tsx
@@ -7,6 +7,7 @@ import { currencyFormat } from "@utils/forms/currency";
 import { StyledContractCard, StyledSeparatorLine } from "./styles";
 
 interface ContractCardProps {
+  contractNumber: number;
   isContractValid: boolean;
   startDate: string;
   endDate: string;

--- a/src/components/modals/SelectModal/index.tsx
+++ b/src/components/modals/SelectModal/index.tsx
@@ -1,0 +1,145 @@
+import {
+  Icon,
+  Stack,
+  Text,
+  useMediaQuery,
+  Blanket,
+  Divider,
+  Button,
+  Select,
+  IOption,
+} from "@inubekit/inubekit";
+import { createPortal } from "react-dom";
+import { MdClear } from "react-icons/md";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+
+import { spacing } from "@design/tokens/spacing";
+import { isRequired } from "@utils/forms";
+import { validationMessages } from "@validations/validationMessages";
+
+import { StyledModal, StyledContainerClose } from "./styles";
+import { FormValues } from "./types";
+
+export interface SelectModalProps {
+  title: string;
+  description: string;
+  portalId?: string;
+  loading?: boolean;
+  selectionOptions?: IOption[];
+  onCloseModal?: () => void;
+  onSubmit?: (values: FormValues) => void;
+}
+
+export function SelectModal(props: SelectModalProps) {
+  const {
+    title = "default title",
+    description = "default description",
+    portalId = "portal",
+    loading = false,
+    selectionOptions = [],
+    onCloseModal,
+    onSubmit,
+  } = props;
+
+  const isMobile = useMediaQuery("(max-width: 700px)");
+  const portalNode = document.getElementById(portalId);
+
+  const validationSchema = Yup.object({
+    selection: Yup.string().required(validationMessages.required),
+  });
+
+  const formik = useFormik<FormValues>({
+    initialValues: {
+      selection: "",
+    },
+    validationSchema,
+    onSubmit: (values) => {
+      if (onSubmit) {
+        onSubmit(values);
+      }
+    },
+  });
+
+  const isButtonDisabled = () => {
+    const hasEmptyFields = !formik.values.selection;
+    const hasErrors = Object.keys(formik.errors).length > 0;
+    return hasEmptyFields || hasErrors || loading;
+  };
+
+  if (!portalNode) {
+    throw new Error(
+      "The portal node is not defined. Ensure the specific node exists in the DOM.",
+    );
+  }
+
+  return createPortal(
+    <Blanket>
+      <StyledModal $smallScreen={isMobile}>
+        <Stack alignItems="center" justifyContent="space-between">
+          <Text type="headline" size="small" ellipsis={isMobile}>
+            {title}
+          </Text>
+          <StyledContainerClose onClick={onCloseModal}>
+            <Stack
+              alignItems="center"
+              gap={spacing.s100}
+              padding={isMobile ? "0px 0px 0px 90px" : "0px"}
+            >
+              <Text>Cerrar</Text>
+              <Icon
+                icon={<MdClear />}
+                size="24px"
+                cursorHover
+                appearance="dark"
+              />
+            </Stack>
+          </StyledContainerClose>
+        </Stack>
+        <Divider />
+
+        <Text size="medium" appearance="gray">
+          {description}
+        </Text>
+
+        <form onSubmit={formik.handleSubmit}>
+          <Stack
+            justifyContent="flex-end"
+            gap={spacing.s250}
+            direction="column"
+          >
+            <Select
+              placeholder="Selecciónalo de la lista"
+              name="selection"
+              id="selection"
+              value={formik.values.selection}
+              message={
+                formik.touched.selection ? formik.errors.selection : undefined
+              }
+              size="compact"
+              fullwidth
+              required={isRequired(validationSchema, "selection")}
+              onChange={(name, value) => void formik.setFieldValue(name, value)}
+              onBlur={formik.handleBlur}
+              options={selectionOptions}
+            />
+            <Stack justifyContent="flex-end" gap={spacing.s250}>
+              <Button
+                type="button"
+                onClick={onCloseModal}
+                appearance="gray"
+                variant="outlined"
+              >
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={isButtonDisabled()}>
+                Confirmar
+              </Button>
+            </Stack>
+          </Stack>
+        </form>
+      </StyledModal>
+    </Blanket>,
+    portalNode,
+  );
+}

--- a/src/components/modals/SelectModal/stories/SelectModal.stories.tsx
+++ b/src/components/modals/SelectModal/stories/SelectModal.stories.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { StoryFn, Meta } from "@storybook/react";
+import { Button, IOption } from "@inubekit/inubekit";
+
+import { SelectModal, SelectModalProps } from "..";
+
+const selectionOptions: IOption[] = [
+  { id: "1", label: "contract1", value: "contract1" },
+  { id: "2", label: "contract2", value: "contract2" },
+  { id: "3", label: "contract3", value: "contract3" },
+];
+
+const story: Meta<typeof SelectModal> = {
+  component: SelectModal,
+  title: "components/modals/SelectModal",
+};
+
+const DefaultTemplate: StoryFn<SelectModalProps> = (args) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleShowModal = () => {
+    setShowModal(!showModal);
+  };
+
+  return (
+    <>
+      <Button onClick={handleShowModal}>Open Modal</Button>
+      {showModal && <SelectModal {...args} onCloseModal={handleShowModal} />}
+    </>
+  );
+};
+
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  title: "Selecciona un contrato",
+  description:
+    "Selecciona el contrato sobre el que vas a ejecutar la acción seleccionada.",
+  portalId: "portal",
+  selectionOptions,
+};
+
+export default story;

--- a/src/components/modals/SelectModal/styles.ts
+++ b/src/components/modals/SelectModal/styles.ts
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/inubekit";
+
+import { spacing } from "@design/tokens/spacing";
+
+interface IStyledModal {
+  $smallScreen: boolean;
+  theme?: typeof inube;
+}
+
+const StyledModal = styled.div<IStyledModal>`
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme }) =>
+    theme?.palette?.neutral?.N0 || inube.palette.neutral.N0};
+  width: ${({ $smallScreen }) => ($smallScreen ? "311px" : "402px")};
+  padding: ${({ $smallScreen }) =>
+    $smallScreen ? spacing.s150 : spacing.s300};
+  gap: ${spacing.s200};
+  border-radius: ${spacing.s100};
+`;
+
+const StyledContainerClose = styled.div`
+  cursor: pointer;
+`;
+
+export { StyledModal, StyledContainerClose };

--- a/src/components/modals/SelectModal/types.ts
+++ b/src/components/modals/SelectModal/types.ts
@@ -1,0 +1,3 @@
+export interface FormValues {
+  selection: string;
+}

--- a/src/mocks/contracts/contracts.mock.tsx
+++ b/src/mocks/contracts/contracts.mock.tsx
@@ -2,6 +2,7 @@ import { ContractCardProps } from "@components/cards/ContractCard";
 
 export const contractCardMock: ContractCardProps[] = [
   {
+    contractNumber: 12345,
     isContractValid: true,
     lastSalary: 3290000,
     startDate: "02/Sep/2024",
@@ -15,6 +16,7 @@ export const contractCardMock: ContractCardProps[] = [
     salaryProfile: 3290000,
   },
   {
+    contractNumber: 67895,
     isContractValid: false,
     lastSalary: 2500000,
     startDate: "15/Mar/2022",
@@ -30,6 +32,7 @@ export const contractCardMock: ContractCardProps[] = [
     retirementReason: "Finalización del proyecto",
   },
   {
+    contractNumber: 98762,
     isContractValid: true,
     lastSalary: 4200000,
     startDate: "10/Jun/2023",

--- a/src/pages/contracts/Actions/styles.ts
+++ b/src/pages/contracts/Actions/styles.ts
@@ -35,7 +35,7 @@ const StyledActions = styled.div<IStyledActions>`
   width: 162px;
   height: 144px;
   position: absolute;
-  z-index: 999;
+  z-index: 1;
   right: 10px;
   top: 100%;
   background-color: ${({ theme }) =>

--- a/src/pages/contracts/interface.tsx
+++ b/src/pages/contracts/interface.tsx
@@ -72,22 +72,19 @@ function ContractsUI({
     setModals((prev) => ({ ...prev, [modal]: false }));
 
   const handleTerminate = () => {
-    console.log("Terminate contract");
     openModal("terminate");
   };
 
   const handleRenew = () => {
-    console.log("Renew contract");
     openModal("renew");
   };
 
   const handleModify = () => {
-    console.log("Modify contract");
     openModal("modify");
   };
 
   const handleAddVinculation = () => {
-    console.log("Add Vinculation");
+    console.log("Agregar vinculación");
   };
 
   const handleDetailsClick = (contract: ContractCardProps) => {
@@ -125,11 +122,9 @@ function ContractsUI({
     loading: false,
   };
 
-  const handleSubmit =
-    (action: ModalType) => (values: { selection: string }) => {
-      console.log(`Selected option for ${action}:`, values);
-      closeModal(action);
-    };
+  const handleSubmit = (action: ModalType) => () => {
+    closeModal(action);
+  };
 
   return (
     <>

--- a/src/pages/contracts/interface.tsx
+++ b/src/pages/contracts/interface.tsx
@@ -99,7 +99,7 @@ function ContractsUI({
     .filter((contract) => contract.isContractValid)
     .map((contract, index) => ({
       id: index.toString(),
-      label: `${contract.company} - ${contract.workplace} (${contract.startDate})`,
+      label: `${contract.contractNumber} - ${contract.company}`,
       value: index.toString(),
     }));
 
@@ -107,13 +107,13 @@ function ContractsUI({
     .filter((contract) => contract.endDate !== "Indefinido")
     .map((contract, index) => ({
       id: index.toString(),
-      label: `${contract.company} - ${contract.workplace} (${contract.startDate})`,
+      label: `${contract.contractNumber} - ${contract.company}`,
       value: index.toString(),
     }));
 
   const modifyOptions = contractCardMock.map((contract, index) => ({
     id: index.toString(),
-    label: `${contract.company} - ${contract.workplace} (${contract.startDate})`,
+    label: `${contract.contractNumber} - ${contract.company}`,
     value: index.toString(),
   }));
 

--- a/src/pages/contracts/types.ts
+++ b/src/pages/contracts/types.ts
@@ -1,0 +1,1 @@
+export type ModalType = "terminate" | "renew" | "modify" | "detail";


### PR DESCRIPTION
Create a modal that displays an employee's list of contracts, as shown in [Figma](https://www.figma.com/design/ZgYt9E6YnXdE56JlkNMEnr/ERM-portal?node-id=69-10512&p=f&t=YAocnKZCfxirSQMZ-0).

![image](https://github.com/user-attachments/assets/2fbf1c1b-ed08-4307-90f7-39e0879352e3)

This modal is triggered by the Terminate, Delete, and Edit buttons if the employee has more than one current contract, where information is obtained from the application context.

The scope of this task is to present the window and list all contracts; the "Understood" button should not function.

Acceptance criteria:

Must have the same dimensions as the mockup.
Must have a mobile version.
Must have a Storybook.
Must not display compilation or console errors.