### PR TITLE
erm43 Creación de sección de datos personales para solicitud de vinculación

### DIFF
--- a/src/components/layout/PageTitle/index.tsx
+++ b/src/components/layout/PageTitle/index.tsx
@@ -14,7 +14,7 @@ interface PageTitleProps {
 function PageTitle(props: PageTitleProps) {
   const { title, description, navigatePage } = props;
 
-  const smallScreen = useMediaQuery("(max-width:880px)");
+  const smallScreen = useMediaQuery("(max-width:490px)");
   const navigate = useNavigate();
 
   return (
@@ -30,7 +30,7 @@ function PageTitle(props: PageTitleProps) {
               navigatePage ? navigate(navigatePage) : navigate(-1)
             }
           />
-          <Text as="h1" type="title">
+          <Text as="h1" type="title" size={smallScreen ? "medium" : "large"}>
             {title}
           </Text>
         </Stack>

--- a/src/pages/requests/ApplicationProcess/Components/Actions/config.tsx
+++ b/src/pages/requests/ApplicationProcess/Components/Actions/config.tsx
@@ -1,0 +1,28 @@
+import { MdOutlineCheckCircle, MdClose } from "react-icons/md";
+import { IIconAppearance } from "@inubekit/inubekit";
+
+interface Action {
+  label: string;
+  icon: JSX.Element;
+  appearance: IIconAppearance;
+  onClick?: () => void;
+  isDisabled?: boolean;
+}
+
+export const Actions = (
+  onSeeRequirements?: () => void,
+  onDiscard?: () => void,
+): Action[] => [
+  {
+    label: "Requisitos",
+    icon: <MdOutlineCheckCircle />,
+    appearance: "primary",
+    onClick: onSeeRequirements,
+  },
+  {
+    label: "Descartar",
+    icon: <MdClose />,
+    appearance: "danger",
+    onClick: onDiscard,
+  },
+];

--- a/src/pages/requests/ApplicationProcess/Components/Actions/index.tsx
+++ b/src/pages/requests/ApplicationProcess/Components/Actions/index.tsx
@@ -1,0 +1,104 @@
+import { Stack, Text, Icon } from "@inubekit/inubekit";
+import { MdOutlineInfo, MdClose } from "react-icons/md";
+
+import {
+  StyledContainer,
+  StyledLi,
+  StyledUl,
+  StyledActions,
+  StyledCloseIcon,
+} from "./styles";
+import { Actions } from "./config";
+
+interface ActionModalProps {
+  disableRequirementsAction?: boolean;
+  disableDiscardAction?: boolean;
+  onSeeRequirements?: () => void;
+  onDiscard?: () => void;
+  onClose?: () => void;
+}
+
+export function ActionModal(props: ActionModalProps) {
+  const {
+    disableRequirementsAction,
+    disableDiscardAction,
+    onSeeRequirements,
+    onDiscard,
+    onClose,
+  } = props;
+
+  const actionsLi = Actions(onSeeRequirements, onDiscard);
+
+  const modifiedActions = actionsLi.map((action) => {
+    const isDisabled =
+      action.label === "Requisitos"
+        ? disableRequirementsAction
+        : action.label === "Descartar"
+          ? disableDiscardAction
+          : false;
+
+    return {
+      ...action,
+      isDisabled,
+      appearance: isDisabled ? "gray" : action.appearance,
+    };
+  });
+
+  return (
+    <StyledContainer>
+      <StyledActions>
+        <Stack>
+          <StyledUl>
+            {modifiedActions.map((item, index) => (
+              <StyledLi
+                key={index}
+                onClick={(event) => {
+                  if (item.isDisabled) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    return;
+                  }
+                  item.onClick?.();
+                }}
+                $isDisabled={item.isDisabled}
+              >
+                <Icon
+                  icon={item.icon}
+                  appearance={item.appearance}
+                  disabled={item.isDisabled}
+                  size="18px"
+                />
+                <Text
+                  size="medium"
+                  appearance={item.isDisabled ? "gray" : "dark"}
+                >
+                  {item.label}
+                </Text>
+                {item.isDisabled && (
+                  <Icon
+                    icon={<MdOutlineInfo />}
+                    appearance="primary"
+                    size="16px"
+                    cursorHover
+                    onClick={(event) => {
+                      event.stopPropagation();
+                    }}
+                  />
+                )}
+              </StyledLi>
+            ))}
+          </StyledUl>
+          <StyledCloseIcon>
+            <Icon
+              icon={<MdClose />}
+              appearance="dark"
+              size="18px"
+              onClick={onClose}
+              cursorHover
+            />
+          </StyledCloseIcon>
+        </Stack>
+      </StyledActions>
+    </StyledContainer>
+  );
+}

--- a/src/pages/requests/ApplicationProcess/Components/Actions/styles.ts
+++ b/src/pages/requests/ApplicationProcess/Components/Actions/styles.ts
@@ -1,0 +1,53 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/inubekit";
+
+import { spacing } from "@design/tokens/spacing";
+
+interface IStyledActions {
+  theme: typeof inube;
+}
+
+interface IStyledLi {
+  theme?: typeof inube;
+  $isDisabled?: boolean;
+}
+
+const StyledContainer = styled.div`
+  position: relative;
+`;
+
+const StyledUl = styled.ul`
+  margin: 0px;
+  padding: 0px;
+`;
+
+const StyledLi = styled.li<IStyledLi>`
+  list-style: none;
+  display: flex;
+  align-items: center;
+  padding: 7px 35px 7px 13px;
+  gap: ${spacing.s050};
+  cursor: pointer;
+`;
+
+const StyledActions = styled.div<IStyledActions>`
+  border-radius: 8px;
+  width: 162px;
+  height: 72px;
+  position: absolute;
+  z-index: 1;
+  right: 11px;
+  top: 100%;
+  background-color: ${({ theme }) =>
+    theme?.palette?.neutral?.N0 || inube.palette.neutral.N0};
+  box-shadow: 0px 2px 6px 1px
+    ${({ theme }) => theme?.palette?.neutral?.N40 || inube.palette.neutral.N40};
+`;
+
+const StyledCloseIcon = styled.div`
+  position: absolute;
+  right: 10px;
+  top: 8px;
+`;
+
+export { StyledContainer, StyledUl, StyledLi, StyledActions, StyledCloseIcon };

--- a/src/pages/requests/ApplicationProcess/Components/Actions/type.ts
+++ b/src/pages/requests/ApplicationProcess/Components/Actions/type.ts
@@ -1,0 +1,10 @@
+import { IIconAppearance } from "@inubekit/inubekit";
+
+interface IAction {
+  icon: React.ReactNode;
+  appearance: IIconAppearance;
+  label: string;
+  isDisabled: boolean;
+  onClick?: () => void;
+}
+export type { IAction };

--- a/src/pages/requests/ApplicationProcess/Components/Detail/index.tsx
+++ b/src/pages/requests/ApplicationProcess/Components/Detail/index.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { MdOutlineMoreVert } from "react-icons/md";
+import { Stack, Icon, useMediaQuery } from "@inubekit/inubekit";
+
+import { ActionModal } from "../Actions";
+import { StyledDetail } from "./styles";
+
+interface DetailProps {
+  disableRequirements?: boolean;
+  disableDiscard?: boolean;
+  onSeeRequirements?: () => void;
+  onDiscard?: () => void;
+}
+
+export function Detail(props: DetailProps) {
+  const { disableRequirements, disableDiscard, onSeeRequirements, onDiscard } =
+    props;
+  const isMobile = useMediaQuery("(max-width: 490px)");
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <StyledDetail $isMobile={isMobile}>
+      <Stack justifyContent="center">
+        <Icon
+          icon={<MdOutlineMoreVert />}
+          appearance="dark"
+          size="24px"
+          onClick={() => setModalOpen(!modalOpen)}
+          cursorHover
+        />
+        {modalOpen && (
+          <ActionModal
+            disableRequirementsAction={disableRequirements}
+            disableDiscardAction={disableDiscard}
+            onSeeRequirements={onSeeRequirements}
+            onDiscard={onDiscard}
+            onClose={() => setModalOpen(false)}
+          />
+        )}
+      </Stack>
+    </StyledDetail>
+  );
+}

--- a/src/pages/requests/ApplicationProcess/Components/Detail/styles.ts
+++ b/src/pages/requests/ApplicationProcess/Components/Detail/styles.ts
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/inubekit";
+
+interface IStyledActions {
+  theme: typeof inube;
+  $isMobile?: boolean;
+}
+
+const StyledDetail = styled.div<IStyledActions>`
+  border-radius: 8px;
+  position: absolute;
+  z-index: 1;
+  top: ${({ $isMobile }) => ($isMobile ? "170px" : "190px")};
+  right: ${({ $isMobile }) => ($isMobile ? "20px" : "65px")};
+`;
+
+export { StyledDetail };

--- a/src/pages/requests/ApplicationProcess/Components/RequestSummary/RequestSummary.stories.tsx
+++ b/src/pages/requests/ApplicationProcess/Components/RequestSummary/RequestSummary.stories.tsx
@@ -1,0 +1,38 @@
+import { Meta } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import { RequestSummary, RequestSumaryProps } from ".";
+
+const meta: Meta<typeof RequestSummary> = {
+  title: "components/RequestSummary",
+  component: RequestSummary,
+  argTypes: {
+    canDiscard: { control: "boolean" },
+    canSeeRequirements: { control: "boolean" },
+    isLoading: { control: "boolean" },
+    staffName: { control: "text" },
+    requestNumber: { control: "text" },
+    requestDate: { control: "text" },
+    onDiscard: { action: "Discard clicked" },
+    onSeeRequirements: { action: "Requirements clicked" },
+  },
+};
+
+export const Default = (args: RequestSumaryProps) => (
+  <RequestSummary {...args} />
+);
+
+Default.args = {
+  canDiscard: true,
+  canSeeRequirements: true,
+  isLoading: false,
+  staffName: "John Doe",
+  requestNumber: "123456",
+  requestDate: "2024-03-20",
+  onDiscard: action("onDiscard"),
+  onSeeRequirements: action("onSeeRequirements"),
+};
+
+export const LoadingState = () => <RequestSummary isLoading={true} />;
+
+export default meta;

--- a/src/pages/requests/ApplicationProcess/Components/RequestSummary/index.tsx
+++ b/src/pages/requests/ApplicationProcess/Components/RequestSummary/index.tsx
@@ -137,7 +137,7 @@ function RequestSummary(props: RequestSumaryProps) {
           )}
         </Stack>
         <Divider dashed />
-        <Stack direction="column">
+        <Stack direction="column" gap={spacing.s050}>
           <Stack gap={spacing.s050}>
             <Text type="label" size="medium">
               No. de solicitud:

--- a/src/pages/requests/ApplicationProcess/Components/RequestSummary/index.tsx
+++ b/src/pages/requests/ApplicationProcess/Components/RequestSummary/index.tsx
@@ -1,0 +1,163 @@
+import {
+  Text,
+  useMediaQuery,
+  Icon,
+  Stack,
+  Button,
+  Divider,
+  SkeletonLine,
+} from "@inubekit/inubekit";
+import {
+  MdOutlinePerson,
+  MdOutlineEdit,
+  MdOutlineInfo,
+  MdOutlineCheckCircle,
+  MdClose,
+} from "react-icons/md";
+
+import { spacing } from "@design/tokens/spacing";
+
+import { Detail } from "../Detail";
+import { StyledRequestSummaryContainer } from "./styles";
+
+export interface RequestSumaryProps {
+  canDiscard?: boolean;
+  canSeeRequirements?: boolean;
+  isLoading?: boolean;
+  staffName?: string;
+  requestNumber?: string;
+  requestDate?: string;
+  onDiscard?: () => void;
+  onSeeRequirements?: () => void;
+}
+
+function RequestSummary(props: RequestSumaryProps) {
+  const {
+    canDiscard = true,
+    canSeeRequirements = true,
+    isLoading = false,
+    staffName = "",
+    requestNumber,
+    requestDate,
+    onDiscard,
+    onSeeRequirements,
+  } = props;
+  const isMobile = useMediaQuery("(max-width: 710px)");
+  return (
+    <>
+      {isMobile && (
+        <Detail
+          onDiscard={onDiscard}
+          onSeeRequirements={onSeeRequirements}
+          disableDiscard={!canDiscard}
+          disableRequirements={!canSeeRequirements}
+        />
+      )}
+      <StyledRequestSummaryContainer $isMobile={isMobile}>
+        <Stack justifyContent="space-between" gap={spacing.s200}>
+          <Stack
+            gap={spacing.s150}
+            justifyContent={isMobile ? "space-between" : "flex-start"}
+            alignItems="center"
+            width="100%"
+          >
+            <Stack gap={spacing.s050}>
+              <Icon icon={<MdOutlinePerson />} appearance="dark" size="20px" />
+              <Text type="label" weight="bold">
+                Responsable:
+              </Text>
+            </Stack>
+
+            <Stack gap={spacing.s050} alignItems="center">
+              {isLoading ? (
+                <SkeletonLine animated width="102px" />
+              ) : (
+                <Text type="label" appearance="gray">
+                  {staffName || "Sin responsable"}
+                </Text>
+              )}
+              <Icon
+                icon={<MdOutlineEdit />}
+                appearance="primary"
+                size="16px"
+                cursorHover
+              />
+            </Stack>
+          </Stack>
+          {!isMobile && (
+            <Stack gap={spacing.s200}>
+              <Stack gap={spacing.s025} alignItems="center">
+                <Button
+                  disabled={!canSeeRequirements}
+                  iconBefore={<MdOutlineCheckCircle />}
+                  cursorHover
+                  spacing="compact"
+                  variant="outlined"
+                  onClick={canSeeRequirements ? onSeeRequirements : undefined}
+                >
+                  Requisitos
+                </Button>
+                {!canSeeRequirements && (
+                  <Icon
+                    icon={<MdOutlineInfo />}
+                    appearance="primary"
+                    size="16px"
+                    cursorHover
+                    onClick={() => {
+                      /* no-op */
+                    }}
+                  />
+                )}
+              </Stack>
+              <Stack gap={spacing.s025} alignItems="center">
+                <Button
+                  disabled={!canDiscard}
+                  iconBefore={<MdClose />}
+                  cursorHover
+                  spacing="compact"
+                  appearance="danger"
+                  variant="outlined"
+                  onClick={canDiscard ? onDiscard : undefined}
+                >
+                  Descartar
+                </Button>
+                {!canDiscard && (
+                  <Icon
+                    icon={<MdOutlineInfo />}
+                    appearance="primary"
+                    size="16px"
+                    cursorHover
+                    onClick={() => {
+                      /* no-op */
+                    }}
+                  />
+                )}
+              </Stack>
+            </Stack>
+          )}
+        </Stack>
+        <Divider dashed />
+        <Stack direction="column">
+          <Stack gap={spacing.s050}>
+            <Text type="label" size="medium">
+              No. de solicitud:
+            </Text>
+            <Text appearance="gray" type="label" size="small">
+              {requestNumber ?? "XXXXXX"}
+            </Text>
+          </Stack>
+          <Stack gap={spacing.s050}>
+            <Text type="label" size="medium">
+              Fecha de solicitud:
+            </Text>
+            <Text appearance="gray" type="label" size="small">
+              {requestDate ?? "Sin Fecha"}
+            </Text>
+          </Stack>
+        </Stack>
+      </StyledRequestSummaryContainer>
+    </>
+  );
+}
+
+export { RequestSummary };

--- a/src/pages/requests/ApplicationProcess/Components/RequestSummary/styles.ts
+++ b/src/pages/requests/ApplicationProcess/Components/RequestSummary/styles.ts
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/inubekit";
+
+import { spacing } from "@design/tokens/spacing";
+
+interface StyledRequestSummaryContainerProps {
+  $isMobile: boolean;
+  theme?: typeof inube;
+}
+
+const StyledRequestSummaryContainer = styled.div<StyledRequestSummaryContainerProps>`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.s200};
+  border-radius: ${spacing.s100};
+  border: 1px solid
+    ${({ theme }) =>
+      theme && theme.palette?.neutral?.N30
+        ? theme.palette.neutral.N30
+        : inube.palette.neutral.N30};
+  padding: ${spacing.s100};
+`;
+
+export { StyledRequestSummaryContainer };

--- a/src/pages/requests/ApplicationProcess/interface.tsx
+++ b/src/pages/requests/ApplicationProcess/interface.tsx
@@ -1,5 +1,8 @@
+import { useParams } from "react-router-dom";
 import { AppMenu } from "@components/layout/AppMenu";
 import { IRoute } from "@components/layout/AppMenu/types";
+
+import { RequestSummary } from "./Components/RequestSummary";
 
 interface ApplicationProcessUIProps {
   appName: string;
@@ -9,10 +12,11 @@ interface ApplicationProcessUIProps {
 
 function ApplicationProcessUI(props: ApplicationProcessUIProps) {
   const { appName, appRoute, navigatePage } = props;
+  const { id } = useParams<{ id: string }>();
 
   return (
     <AppMenu appName={appName} appRoute={appRoute} navigatePage={navigatePage}>
-      <></>
+      <RequestSummary requestNumber={id} />
     </AppMenu>
   );
 }


### PR DESCRIPTION
Create a section displaying general employee data, such as the number of requests and the request date, with its requirement and dismiss buttons, as shown in [Figma](https://www.figma.com/design/ZgYt9E6YnXdE56JlkNMEnr/ERM-portal?node-id=109-37056&t=5TS2CX41nDyNNPIb-0).
It must be displayed on the page created in task 42.

![image](https://github.com/user-attachments/assets/17f62ee2-235e-43ce-b6e8-6ee482e28953)

Acceptance criteria.

It must have the same dimensions as the mockup.
It must have a mobile version.
It must not display errors in the console or when compiling typescript.
It must have the same icon designs.
It must be displayed on the individual linking request view page.