### PR TITLE
erm59 Conectar botón de vinculación en contrato

### DIFF
--- a/src/pages/Employees/SelectEmployee/index.tsx
+++ b/src/pages/Employees/SelectEmployee/index.tsx
@@ -32,7 +32,6 @@ function SelectEmployeePage() {
 
   const handleOpenNewEmployeePage = () => {
     window.open("/employees/new-employee", "_blank");
-    window.close();
   };
 
   return (

--- a/src/pages/Employees/SelectEmployee/index.tsx
+++ b/src/pages/Employees/SelectEmployee/index.tsx
@@ -1,4 +1,3 @@
-import { Formik, FormikProps } from "formik";
 import {
   Text,
   Button,
@@ -7,15 +6,17 @@ import {
   Spinner,
   useMediaQuery,
 } from "@inubekit/inubekit";
+import { Formik, FormikProps } from "formik";
+import { Link } from "react-router-dom";
 import { MdOutlineAdd, MdOutlineArrowForward } from "react-icons/md";
+
 import { spacing } from "@design/tokens/spacing";
-import { StyledAppPage, StyledQuickAccessContainer } from "./styles";
-import { useSelectEmployee } from "./interface";
 import { SearchInput } from "@components/data/EmployeeSearchInput";
 
-function SelectEmployeePage() {
-  const isMobile = useMediaQuery("(max-width: 768px)");
+import { StyledAppPage, StyledQuickAccessContainer } from "./styles";
+import { useSelectEmployee } from "./interface";
 
+function SelectEmployeePage() {
   const {
     filteredEmployees,
     loading,
@@ -27,6 +28,8 @@ function SelectEmployeePage() {
     selectedEmployee,
     handleSubmit,
   } = useSelectEmployee();
+
+  const isMobile = useMediaQuery("(max-width: 768px)");
 
   return (
     <Formik
@@ -130,18 +133,20 @@ function SelectEmployeePage() {
             </StyledQuickAccessContainer>
 
             <Stack justifyContent="end">
-              <Button
-                appearance="primary"
-                iconBefore={<MdOutlineAdd />}
-                variant="none"
-                spacing="wide"
-                type="button"
-                onClick={() => {
-                  console.log("Redirigir a vincular nuevo empleado");
-                }}
+              <Link
+                to="/employees/new-employee"
+                target="_blank"
+                rel="noopener noreferrer"
               >
-                Vincular nuevo empleado
-              </Button>
+                <Button
+                  appearance="primary"
+                  iconBefore={<MdOutlineAdd />}
+                  variant="none"
+                  spacing="wide"
+                >
+                  Vincular nuevo empleado
+                </Button>
+              </Link>
             </Stack>
           </Stack>
         </StyledAppPage>

--- a/src/pages/Employees/SelectEmployee/index.tsx
+++ b/src/pages/Employees/SelectEmployee/index.tsx
@@ -7,7 +7,6 @@ import {
   useMediaQuery,
 } from "@inubekit/inubekit";
 import { Formik, FormikProps } from "formik";
-import { Link } from "react-router-dom";
 import { MdOutlineAdd, MdOutlineArrowForward } from "react-icons/md";
 
 import { spacing } from "@design/tokens/spacing";
@@ -30,6 +29,11 @@ function SelectEmployeePage() {
   } = useSelectEmployee();
 
   const isMobile = useMediaQuery("(max-width: 768px)");
+
+  const handleOpenNewEmployeePage = () => {
+    window.open("/employees/new-employee", "_blank");
+    window.close();
+  };
 
   return (
     <Formik
@@ -133,20 +137,15 @@ function SelectEmployeePage() {
             </StyledQuickAccessContainer>
 
             <Stack justifyContent="end">
-              <Link
-                to="/employees/new-employee"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Button
+                appearance="primary"
+                iconBefore={<MdOutlineAdd />}
+                variant="none"
+                spacing="wide"
+                onClick={handleOpenNewEmployeePage}
               >
-                <Button
-                  appearance="primary"
-                  iconBefore={<MdOutlineAdd />}
-                  variant="none"
-                  spacing="wide"
-                >
-                  Vincular nuevo empleado
-                </Button>
-              </Link>
+                Vincular nuevo empleado
+              </Button>
             </Stack>
           </Stack>
         </StyledAppPage>

--- a/src/pages/contracts/index.tsx
+++ b/src/pages/contracts/index.tsx
@@ -72,6 +72,7 @@ function Contracts(props: ContractsProps) {
 
   const handleAddVinculation = () => {
     window.open("/employees/new-employee", "_blank");
+    window.close();
   };
 
   const handleDetailsClick = (contract: ContractCardProps) => {

--- a/src/pages/contracts/index.tsx
+++ b/src/pages/contracts/index.tsx
@@ -71,7 +71,7 @@ function Contracts(props: ContractsProps) {
   };
 
   const handleAddVinculation = () => {
-    console.log("Agregar vinculación");
+    window.open("/employees/new-employee", "_blank");
   };
 
   const handleDetailsClick = (contract: ContractCardProps) => {

--- a/src/pages/contracts/index.tsx
+++ b/src/pages/contracts/index.tsx
@@ -72,7 +72,6 @@ function Contracts(props: ContractsProps) {
 
   const handleAddVinculation = () => {
     window.open("/employees/new-employee", "_blank");
-    window.close();
   };
 
   const handleDetailsClick = (contract: ContractCardProps) => {

--- a/src/pages/contracts/interface.tsx
+++ b/src/pages/contracts/interface.tsx
@@ -25,7 +25,6 @@ import {
   StyledSeparatorLine,
   StyledAddVinculation,
   StyledAddVinculationMobile,
-  StyledLink,
 } from "./styles";
 import { Detail } from "./Detail";
 import { ModalType } from "./types";
@@ -214,21 +213,15 @@ function ContractsUI(props: ContractsUIProps) {
                   )}
                 </Stack>
                 <Stack gap={spacing.s025} alignItems="center">
-                  <StyledLink
-                    to="/employees/new-employee"
-                    target="_blank"
-                    rel="noopener noreferrer"
+                  <Button
+                    disabled={!canCreateRequest}
+                    iconBefore={<MdOutlineAdd />}
+                    cursorHover
+                    spacing="compact"
+                    onClick={canCreateRequest ? onAddVinculation : undefined}
                   >
-                    <Button
-                      disabled={!canCreateRequest}
-                      iconBefore={<MdOutlineAdd />}
-                      cursorHover
-                      spacing="compact"
-                      onClick={canCreateRequest ? onAddVinculation : undefined}
-                    >
-                      Agregar vinculación
-                    </Button>
-                  </StyledLink>
+                    Agregar vinculación
+                  </Button>
                   {!canCreateRequest && (
                     <Icon
                       icon={<MdOutlineInfo />}
@@ -274,33 +267,24 @@ function ContractsUI(props: ContractsUIProps) {
               />
             ))}
             {canCreateRequest && !isTablet && (
-              <StyledLink
-                to="/employees/new-employee"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <div onClick={canCreateRequest ? onAddVinculation : undefined}>
                 <StyledAddVinculation>
                   <Icon
                     appearance="gray"
                     icon={<MdOutlineAdd />}
                     size="45px"
-                    onClick={canCreateRequest ? onAddVinculation : undefined}
                     cursorHover={canCreateRequest}
                   />
                   <Text appearance="gray">Agregar vinculación</Text>
                 </StyledAddVinculation>
-              </StyledLink>
+              </div>
             )}
           </Stack>
         </StyledContractsContainer>
       </AppMenu>
 
       {isTablet && canCreateRequest && (
-        <StyledLink
-          to="/employees/new-employee"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <div onClick={canCreateRequest ? onAddVinculation : undefined}>
           <StyledAddVinculationMobile>
             <Icon
               appearance="primary"
@@ -310,10 +294,9 @@ function ContractsUI(props: ContractsUIProps) {
               icon={<MdOutlineAdd />}
               size="50px"
               cursorHover={canCreateRequest}
-              onClick={canCreateRequest ? onAddVinculation : undefined}
             />
           </StyledAddVinculationMobile>
-        </StyledLink>
+        </div>
       )}
 
       {modals.detail && selectedContract && (

--- a/src/pages/contracts/interface.tsx
+++ b/src/pages/contracts/interface.tsx
@@ -25,6 +25,7 @@ import {
   StyledSeparatorLine,
   StyledAddVinculation,
   StyledAddVinculationMobile,
+  StyledLink,
 } from "./styles";
 import { Detail } from "./Detail";
 import { ModalType } from "./types";
@@ -213,15 +214,21 @@ function ContractsUI(props: ContractsUIProps) {
                   )}
                 </Stack>
                 <Stack gap={spacing.s025} alignItems="center">
-                  <Button
-                    disabled={!canCreateRequest}
-                    iconBefore={<MdOutlineAdd />}
-                    cursorHover
-                    spacing="compact"
-                    onClick={canCreateRequest ? onAddVinculation : undefined}
+                  <StyledLink
+                    to="/employees/new-employee"
+                    target="_blank"
+                    rel="noopener noreferrer"
                   >
-                    Agregar vinculación
-                  </Button>
+                    <Button
+                      disabled={!canCreateRequest}
+                      iconBefore={<MdOutlineAdd />}
+                      cursorHover
+                      spacing="compact"
+                      onClick={canCreateRequest ? onAddVinculation : undefined}
+                    >
+                      Agregar vinculación
+                    </Button>
+                  </StyledLink>
                   {!canCreateRequest && (
                     <Icon
                       icon={<MdOutlineInfo />}
@@ -267,34 +274,46 @@ function ContractsUI(props: ContractsUIProps) {
               />
             ))}
             {canCreateRequest && !isTablet && (
-              <StyledAddVinculation>
-                <Icon
-                  appearance="gray"
-                  icon={<MdOutlineAdd />}
-                  size="45px"
-                  onClick={canCreateRequest ? onAddVinculation : undefined}
-                  cursorHover={canCreateRequest}
-                />
-                <Text appearance="gray">Agregar vinculación</Text>
-              </StyledAddVinculation>
+              <StyledLink
+                to="/employees/new-employee"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <StyledAddVinculation>
+                  <Icon
+                    appearance="gray"
+                    icon={<MdOutlineAdd />}
+                    size="45px"
+                    onClick={canCreateRequest ? onAddVinculation : undefined}
+                    cursorHover={canCreateRequest}
+                  />
+                  <Text appearance="gray">Agregar vinculación</Text>
+                </StyledAddVinculation>
+              </StyledLink>
             )}
           </Stack>
         </StyledContractsContainer>
       </AppMenu>
 
       {isTablet && canCreateRequest && (
-        <StyledAddVinculationMobile>
-          <Icon
-            appearance="primary"
-            variant="filled"
-            spacing="wide"
-            shape="circle"
-            icon={<MdOutlineAdd />}
-            size="50px"
-            cursorHover={canCreateRequest}
-            onClick={canCreateRequest ? onAddVinculation : undefined}
-          />
-        </StyledAddVinculationMobile>
+        <StyledLink
+          to="/employees/new-employee"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <StyledAddVinculationMobile>
+            <Icon
+              appearance="primary"
+              variant="filled"
+              spacing="wide"
+              shape="circle"
+              icon={<MdOutlineAdd />}
+              size="50px"
+              cursorHover={canCreateRequest}
+              onClick={canCreateRequest ? onAddVinculation : undefined}
+            />
+          </StyledAddVinculationMobile>
+        </StyledLink>
       )}
 
       {modals.detail && selectedContract && (

--- a/src/pages/contracts/styles.ts
+++ b/src/pages/contracts/styles.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { inube } from "@inubekit/inubekit";
+import { Link as RouterLink } from "react-router-dom";
 
 import { spacing } from "@design/tokens/spacing";
 
@@ -56,9 +57,14 @@ const StyledAddVinculationMobile = styled.div`
   bottom: ${spacing.s500};
 `;
 
+const StyledLink = styled(RouterLink)`
+  text-decoration: none;
+`;
+
 export {
   StyledContractsContainer,
   StyledSeparatorLine,
   StyledAddVinculation,
   StyledAddVinculationMobile,
+  StyledLink,
 };

--- a/src/pages/contracts/styles.ts
+++ b/src/pages/contracts/styles.ts
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { inube } from "@inubekit/inubekit";
-import { Link as RouterLink } from "react-router-dom";
 
 import { spacing } from "@design/tokens/spacing";
 
@@ -57,14 +56,9 @@ const StyledAddVinculationMobile = styled.div`
   bottom: ${spacing.s500};
 `;
 
-const StyledLink = styled(RouterLink)`
-  text-decoration: none;
-`;
-
 export {
   StyledContractsContainer,
   StyledSeparatorLine,
   StyledAddVinculation,
   StyledAddVinculationMobile,
-  StyledLink,
 };


### PR DESCRIPTION
Add functionality to the linking button to redirect the employee to the linking assistant page, which should open in a new browser tab and close the current one.
The areas where this functionality should be expanded are:
Employee selection

![image](https://github.com/user-attachments/assets/31eed3c6-eda6-45e4-b022-8aa3670979da)
![image](https://github.com/user-attachments/assets/892aa379-12b8-4e82-943e-5180314f8469)

Acceptance criteria:

Must open in a separate tab
Must have no errors in console or typescript compilation
Must display the help